### PR TITLE
feat(iter-2): диалог — session.opened, question.asked, answer.given, статичный Core

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,7 @@ OPENAI_IMAGE_MODEL=
 DATABASE_URL=postgres://user:pass@localhost:5432/aeon
 # Интеграционные тесты: отдельная БД (TRUNCATE events). Создать: npm run test:db:prepare
 TEST_DATABASE_URL=postgres://user:pass@127.0.0.1:5433/aeon_test
+# Сброс событий вручную: npm run db:clear (DATABASE_URL) или npm run db:clear:test (TEST_DATABASE_URL)
 
 # Наблюдаемость
 OTEL_EXPORTER_OTLP_ENDPOINT=

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ MAX_WEBHOOK_PUBLIC_URL=
 # База HTTP API (по умолчанию прод MAX)
 MAX_API_BASE_URL=https://platform-api.max.ru
 
+# Диалог iter-2 (опционально; иначе дефолты в config.ts)
+# FIRST_CORE_QUESTION_TEXT=
+# DIALOG_ANSWER_ACK_TEXT=
+
 # Anthropic (основной LLM)
 ANTHROPIC_API_KEY=
 ANTHROPIC_MODEL=claude-sonnet-4-6

--- a/docs/SPEC/events.md
+++ b/docs/SPEC/events.md
@@ -25,6 +25,14 @@
 
 **Идемпотентность `user.started` (iter 1, вариант B):** ключ строки в БД — `idempotency_key = user.started:${max_user_id}`. Повторная доставка того же или другого update для уже известного пользователя не создаёт вторую строку `user.started`. В `payload` события допускается поле `max_update_id` для связи с конкретным вебхуком.
 
+### Диалог iter-2 (первый статичный вопрос Core)
+
+- **`correlation_id`** для `session.opened`, `question.asked`, `answer.given` одной сессии: строка **`session_id`** (UUID v7).
+- В **`payload`** этих событий всегда есть **`max_user_id`** (число), чтобы выбирать цепочку по пользователю без отдельной таблицы сессий.
+- **`session.opened` (iter-2):** `idempotency_key = session.opened:iter2:${max_user_id}` — одна такая сессия на пользователя в рамках iter-2. В payload опционально **`opening_message_mid`**: `message.body.mid` того `message_created`, после которого открыли сессию (если вход через текст пользователя). Нужен, чтобы **повторный вебхук с тем же mid** не записывался как `answer.given`. Для входа через **`bot_started`** поле не задаётся.
+- **`question.asked` (первый вопрос Core):** `question_id = core:first`, `idempotency_key = question.asked:iter2:core:first:${max_user_id}`, в payload **`llm_call_id: null`**, текст вопроса из конфига приложения (`FIRST_CORE_QUESTION_TEXT` / дефолт в `config.ts`).
+- **`answer.given`:** `idempotency_key = answer.given:${max_update_id}` (см. INV-07). В payload: **`max_update_id`**, **`max_user_id`**, **`answer_type`** (iter-2: `text`), **`answer_value`** — текст ответа.
+
 ---
 
 ## Каталог `event_type`
@@ -32,9 +40,9 @@
 | type | Триггер | payload (поля) | causation / примечание |
 |------|---------|----------------|------------------------|
 | **user.started** | Первый вход /start в MAX | max_user_id, locale, referral_source | — |
-| **session.opened** | Бот открыл сессию | session_id, layer, question_count_plan | после user.started или логики возврата |
-| **question.asked** | Бот отправил вопрос | session_id, question_id, question_text, layer, llm_call_id | может следовать за llm.called |
-| **answer.given** | Пользователь ответил | session_id, question_id, answer_value, answer_type | **неизменяем**; causation для card_signal.received |
+| **session.opened** | Бот открыл сессию | session_id, layer, question_count_plan; iter-2: max_user_id, опц. opening_message_mid | после user.started или логики возврата |
+| **question.asked** | Бот отправил вопрос | session_id, question_id, question_text, layer, llm_call_id; iter-2: max_user_id | может следовать за llm.called |
+| **answer.given** | Пользователь ответил | session_id, question_id, answer_value, answer_type; iter-2: max_user_id, max_update_id | **неизменяем**; causation для card_signal.received |
 | **card_signal.received** | Классификатор сигналов | answer_id, user_id, card_type, weight, source_layer | несколько на один answer.given |
 | **llm.called** | Вызов Claude/OpenAI | session_id, model, prompt_version, input_hash, latency_ms | до отправки сообщения пользователю (INV-06) |
 | **card.computed** | Stability Engine назначил карту | card_type, confidence, input_answer_ids, version | после порогов сигналов + confidence |

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test:watch": "vitest",
     "test:db:prepare": "node scripts/ensure-test-db.mjs",
     "test:all": "npm run test:db:prepare && npm run test",
+    "db:clear": "node --env-file=.env scripts/clear-events.mjs",
+    "db:clear:test": "node scripts/clear-events.mjs --test",
     "max:subscribe": "node --env-file=.env scripts/register-max-subscription.mjs",
     "max:subscriptions": "node --env-file=.env scripts/register-max-subscription.mjs --status"
   },

--- a/scripts/clear-events.mjs
+++ b/scripts/clear-events.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * Очищает таблицу events (ручное тестирование / сброс диалога).
+ *
+ * По умолчанию: DATABASE_URL из окружения.
+ * Флаг --test: TEST_DATABASE_URL или дефолт как в ensure-test-db.mjs.
+ *
+ * Примеры:
+ *   npm run db:clear
+ *   npm run db:clear:test
+ */
+import pg from 'pg';
+
+const FALLBACK_TEST_URL = 'postgres://aeon:aeon@127.0.0.1:5433/aeon_test';
+
+const useTest = process.argv.includes('--test');
+const connectionString = useTest
+  ? (process.env.TEST_DATABASE_URL ?? FALLBACK_TEST_URL)
+  : process.env.DATABASE_URL;
+
+if (!connectionString) {
+  console.error(
+    'clear-events: задай DATABASE_URL (или npm run db:clear с --env-file=.env), либо запусти с --test для TEST_DATABASE_URL',
+  );
+  process.exit(1);
+}
+
+let dbLabel = connectionString;
+try {
+  const u = new URL(connectionString);
+  dbLabel = `${u.hostname}:${u.port || '5432'}${u.pathname}`;
+} catch {
+  /* keep raw */
+}
+
+const pool = new pg.Pool({ connectionString });
+try {
+  await pool.query('TRUNCATE events');
+  console.log(`clear-events: TRUNCATE events — ${dbLabel}${useTest ? ' (--test)' : ''}`);
+} catch (e) {
+  console.error('clear-events:', e instanceof Error ? e.message : e);
+  process.exit(1);
+} finally {
+  await pool.end();
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,10 @@ export type Config = {
   maxWebhookSecret: string;
   maxApiBaseUrl: string;
   logLevel: string;
+  /** Статичный первый вопрос Core (iter-2). */
+  firstCoreQuestionText: string;
+  /** Короткое подтверждение после answer.given. */
+  dialogAnswerAckText: string;
 };
 
 export function loadConfig(): Config {
@@ -15,5 +19,9 @@ export function loadConfig(): Config {
     maxWebhookSecret: process.env.MAX_WEBHOOK_SECRET ?? '',
     maxApiBaseUrl: process.env.MAX_API_BASE_URL ?? 'https://platform-api.max.ru',
     logLevel: process.env.LOG_LEVEL ?? 'info',
+    firstCoreQuestionText:
+      process.env.FIRST_CORE_QUESTION_TEXT ??
+      'Привет! С чего хочешь начать разговор о себе — про работу и цели, про отношения или про ощущение смысла?',
+    dialogAnswerAckText: process.env.DIALOG_ANSWER_ACK_TEXT ?? 'Спасибо, ответ записан!',
   };
 }

--- a/src/db/dialog-events.ts
+++ b/src/db/dialog-events.ts
@@ -1,0 +1,28 @@
+import type { Pool } from 'pg';
+import type { DialogEventRow } from '../dialog/resolve-state.js';
+
+const DIALOG_EVENT_TYPES = ['user.started', 'session.opened', 'question.asked', 'answer.given'] as const;
+
+/** События диалога для пользователя MAX (фильтр по payload.max_user_id). */
+export async function fetchDialogEventsForUser(pool: Pool, maxUserId: number): Promise<DialogEventRow[]> {
+  const r = await pool.query<{ event_type: string; payload: Record<string, unknown> }>(
+    `SELECT event_type, payload
+     FROM events
+     WHERE event_type = ANY($1::text[])
+       AND (payload->>'max_user_id') = $2
+     ORDER BY occurred_at ASC`,
+    [DIALOG_EVENT_TYPES, String(maxUserId)],
+  );
+  return r.rows;
+}
+
+export async function getPayloadByIdempotencyKey(
+  pool: Pool,
+  idempotencyKey: string,
+): Promise<Record<string, unknown> | null> {
+  const r = await pool.query<{ payload: Record<string, unknown> }>(
+    `SELECT payload FROM events WHERE idempotency_key = $1 LIMIT 1`,
+    [idempotencyKey],
+  );
+  return r.rows[0]?.payload ?? null;
+}

--- a/src/db/session-events.ts
+++ b/src/db/session-events.ts
@@ -1,0 +1,116 @@
+import { v7 as uuidv7 } from 'uuid';
+import type { Pool } from 'pg';
+import { CORE_FIRST_QUESTION_ID, DIALOG_LAYER_CORE } from '../dialog/constants.js';
+import { getPayloadByIdempotencyKey } from './dialog-events.js';
+import { insertEvent } from './insert-event.js';
+
+export type InsertSessionOpenedParams = {
+  maxUserId: number;
+  sessionId: string;
+  /** mid первого message_created, из которого открыли сессию; для bot_started не задавать. */
+  openingMessageMid?: string | null;
+};
+
+/** Одна сессия iter-2 на пользователя (идемпотентность). */
+export async function insertSessionOpened(
+  pool: Pool,
+  params: InsertSessionOpenedParams,
+): Promise<'inserted' | 'duplicate'> {
+  const payload: Record<string, unknown> = {
+    session_id: params.sessionId,
+    layer: DIALOG_LAYER_CORE,
+    question_count_plan: [1],
+    max_user_id: params.maxUserId,
+  };
+  if (params.openingMessageMid != null && params.openingMessageMid !== '') {
+    payload.opening_message_mid = params.openingMessageMid;
+  }
+
+  return insertEvent(pool, {
+    eventType: 'session.opened',
+    actor: { id: 'aeon-max-bot', role: 'service' },
+    subject: { entity: 'session', id: params.sessionId },
+    payload,
+    idempotencyKey: `session.opened:iter2:${params.maxUserId}`,
+    schemaVersion: 1,
+    correlationId: params.sessionId,
+  });
+}
+
+/** Вставляет session.opened (iter-2) или возвращает session_id из уже существующей строки. */
+export async function ensureIter2SessionAndGetId(
+  pool: Pool,
+  params: InsertSessionOpenedParams,
+): Promise<string> {
+  const key = `session.opened:iter2:${params.maxUserId}`;
+  const ins = await insertSessionOpened(pool, params);
+  if (ins === 'inserted') {
+    return params.sessionId;
+  }
+  const payload = await getPayloadByIdempotencyKey(pool, key);
+  const sid = payload?.session_id;
+  if (sid == null) {
+    throw new Error(`session.opened duplicate but payload missing session_id for user ${params.maxUserId}`);
+  }
+  return String(sid);
+}
+
+/** Вызывать после успешного insertSessionOpened с тем же sessionId и openingMessageMid. */
+export async function insertQuestionAskedFirstCore(
+  pool: Pool,
+  params: {
+    maxUserId: number;
+    sessionId: string;
+    questionText: string;
+  },
+): Promise<'inserted' | 'duplicate'> {
+  return insertEvent(pool, {
+    eventType: 'question.asked',
+    actor: { id: 'aeon-max-bot', role: 'service' },
+    subject: { entity: 'session', id: params.sessionId },
+    payload: {
+      session_id: params.sessionId,
+      question_id: CORE_FIRST_QUESTION_ID,
+      question_text: params.questionText,
+      layer: DIALOG_LAYER_CORE,
+      llm_call_id: null,
+      max_user_id: params.maxUserId,
+    },
+    idempotencyKey: `question.asked:iter2:${CORE_FIRST_QUESTION_ID}:${params.maxUserId}`,
+    schemaVersion: 1,
+    correlationId: params.sessionId,
+  });
+}
+
+export async function insertAnswerGiven(
+  pool: Pool,
+  params: {
+    maxUserId: number;
+    sessionId: string;
+    questionId: string;
+    answerValue: string;
+    answerType: string;
+    maxUpdateId: string;
+  },
+): Promise<'inserted' | 'duplicate'> {
+  return insertEvent(pool, {
+    eventType: 'answer.given',
+    actor: { id: String(params.maxUserId), role: 'user' },
+    subject: { entity: 'session', id: params.sessionId },
+    payload: {
+      session_id: params.sessionId,
+      question_id: params.questionId,
+      answer_value: params.answerValue,
+      answer_type: params.answerType,
+      max_user_id: params.maxUserId,
+      max_update_id: params.maxUpdateId,
+    },
+    idempotencyKey: `answer.given:${params.maxUpdateId}`,
+    schemaVersion: 1,
+    correlationId: params.sessionId,
+  });
+}
+
+export function newSessionId(): string {
+  return uuidv7();
+}

--- a/src/dialog/constants.ts
+++ b/src/dialog/constants.ts
@@ -1,0 +1,4 @@
+/** Статичный первый вопрос Core Layer (iter-2). */
+export const CORE_FIRST_QUESTION_ID = 'core:first';
+
+export const DIALOG_LAYER_CORE = 'core';

--- a/src/dialog/resolve-state.ts
+++ b/src/dialog/resolve-state.ts
@@ -1,0 +1,82 @@
+import { CORE_FIRST_QUESTION_ID } from './constants.js';
+
+export type DialogEventRow = {
+  event_type: string;
+  payload: Record<string, unknown>;
+};
+
+export type DialogState =
+  | { type: 'needs_first_question' }
+  | { type: 'awaiting_answer'; sessionId: string; questionId: string; openingMessageMid: string | null }
+  | { type: 'answered' };
+
+function openingMidForSession(events: DialogEventRow[], sessionId: string): string | null {
+  for (const e of events) {
+    if (e.event_type === 'session.opened' && String(e.payload.session_id) === sessionId) {
+      const om = e.payload.opening_message_mid;
+      return om != null && om !== '' ? String(om) : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Выводит состояние диалога iter-2 по хронологии событий пользователя (user.started, session, question, answer).
+ */
+export function inferDialogState(events: DialogEventRow[]): DialogState {
+  let currentSessionId: string | null = null;
+  let pendingCoreQuestionSessionId: string | null = null;
+  let answeredCoreFirst = false;
+
+  for (const e of events) {
+    switch (e.event_type) {
+      case 'session.opened': {
+        const sid = e.payload.session_id;
+        if (sid != null) {
+          currentSessionId = String(sid);
+        }
+        pendingCoreQuestionSessionId = null;
+        break;
+      }
+      case 'question.asked': {
+        if (
+          e.payload.question_id === CORE_FIRST_QUESTION_ID &&
+          currentSessionId != null &&
+          String(e.payload.session_id) === currentSessionId
+        ) {
+          pendingCoreQuestionSessionId = currentSessionId;
+        }
+        break;
+      }
+      case 'answer.given': {
+        if (e.payload.question_id === CORE_FIRST_QUESTION_ID) {
+          answeredCoreFirst = true;
+          pendingCoreQuestionSessionId = null;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  if (answeredCoreFirst) {
+    return { type: 'answered' };
+  }
+
+  if (pendingCoreQuestionSessionId != null) {
+    return {
+      type: 'awaiting_answer',
+      sessionId: pendingCoreQuestionSessionId,
+      questionId: CORE_FIRST_QUESTION_ID,
+      openingMessageMid: openingMidForSession(events, pendingCoreQuestionSessionId),
+    };
+  }
+
+  const hasUserStarted = events.some((x) => x.event_type === 'user.started');
+  if (hasUserStarted) {
+    return { type: 'needs_first_question' };
+  }
+
+  return { type: 'needs_first_question' };
+}

--- a/src/services/webhook-service.ts
+++ b/src/services/webhook-service.ts
@@ -1,6 +1,14 @@
 import type { Pool } from 'pg';
 import type { Config } from '../config.js';
+import { inferDialogState } from '../dialog/resolve-state.js';
+import { fetchDialogEventsForUser } from '../db/dialog-events.js';
 import { insertUserStarted } from '../db/events.js';
+import {
+  ensureIter2SessionAndGetId,
+  insertAnswerGiven,
+  insertQuestionAskedFirstCore,
+  newSessionId,
+} from '../db/session-events.js';
 import { sendMaxUserMessage } from '../integrations/max/client.js';
 import type { BotStartedUpdate, MaxUpdate, MessageCreatedUpdate } from '../integrations/max/types.js';
 import { resolveMaxUpdateId } from '../integrations/max/update-id.js';
@@ -13,14 +21,43 @@ function isMessageCreated(u: MaxUpdate): u is MessageCreatedUpdate {
   return u.update_type === 'message_created' && 'message' in u && u.message != null;
 }
 
-export async function handleMaxWebhook(
-  opts: {
-    config: Config;
-    pool: Pool;
-    update: MaxUpdate;
-    log: { warn: (o: unknown, msg?: string) => void; info: (o: unknown, msg?: string) => void };
-  },
-): Promise<{ duplicate: boolean; skipped: boolean }> {
+async function openIter2SessionAndAskFirstQuestion(opts: {
+  pool: Pool;
+  config: Config;
+  maxUserId: number;
+  openingMessageMid: string | null;
+  log: { warn: (o: unknown, msg?: string) => void };
+}): Promise<void> {
+  const { pool, config, maxUserId, openingMessageMid, log } = opts;
+  const candidate = newSessionId();
+  const sessionId = await ensureIter2SessionAndGetId(pool, {
+    maxUserId,
+    sessionId: candidate,
+    openingMessageMid: openingMessageMid ?? undefined,
+  });
+  const qIns = await insertQuestionAskedFirstCore(pool, {
+    maxUserId,
+    sessionId,
+    questionText: config.firstCoreQuestionText,
+  });
+  if (qIns === 'inserted' && config.maxBotToken) {
+    await sendMaxUserMessage({
+      baseUrl: config.maxApiBaseUrl,
+      token: config.maxBotToken,
+      userId: maxUserId,
+      text: config.firstCoreQuestionText,
+    });
+  } else if (qIns === 'inserted' && !config.maxBotToken) {
+    log.warn('MAX_BOT_TOKEN empty: skip outbound first question');
+  }
+}
+
+export async function handleMaxWebhook(opts: {
+  config: Config;
+  pool: Pool;
+  update: MaxUpdate;
+  log: { warn: (o: unknown, msg?: string) => void; info: (o: unknown, msg?: string) => void };
+}): Promise<{ duplicate: boolean; skipped: boolean }> {
   const { config, pool, update, log } = opts;
   const maxUpdateId = resolveMaxUpdateId(update);
   if (!maxUpdateId) {
@@ -29,23 +66,25 @@ export async function handleMaxWebhook(
   }
 
   if (isBotStarted(update)) {
-    const ins = await insertUserStarted(pool, {
-      userId: update.user.user_id,
+    const userId = update.user.user_id;
+    const userIns = await insertUserStarted(pool, {
+      userId,
       locale: null,
       referralSource: typeof update.payload === 'string' ? update.payload : null,
       maxUpdateId,
     });
-    if (ins === 'inserted' && config.maxBotToken) {
-      await sendMaxUserMessage({
-        baseUrl: config.maxApiBaseUrl,
-        token: config.maxBotToken,
-        userId: update.user.user_id,
-        text: 'Привет!',
+    const rows = await fetchDialogEventsForUser(pool, userId);
+    const state = inferDialogState(rows);
+    if (state.type === 'needs_first_question') {
+      await openIter2SessionAndAskFirstQuestion({
+        pool,
+        config,
+        maxUserId: userId,
+        openingMessageMid: null,
+        log,
       });
-    } else if (ins === 'inserted' && !config.maxBotToken) {
-      log.warn('MAX_BOT_TOKEN empty: skip outbound message');
     }
-    return { duplicate: ins === 'duplicate', skipped: false };
+    return { duplicate: userIns === 'duplicate', skipped: false };
   }
 
   if (isMessageCreated(update)) {
@@ -58,23 +97,59 @@ export async function handleMaxWebhook(
       log.warn({ update }, 'message_created without sender.user_id');
       return { duplicate: false, skipped: true };
     }
-    const ins = await insertUserStarted(pool, {
+
+    const userIns = await insertUserStarted(pool, {
       userId: uid,
       locale: update.user_locale ?? null,
       referralSource: null,
       maxUpdateId,
     });
-    if (ins === 'inserted' && config.maxBotToken) {
-      await sendMaxUserMessage({
-        baseUrl: config.maxApiBaseUrl,
-        token: config.maxBotToken,
-        userId: uid,
-        text: 'Привет!',
-      });
-    } else     if (ins === 'inserted' && !config.maxBotToken) {
-      log.warn('MAX_BOT_TOKEN empty: skip outbound message');
+
+    const rows = await fetchDialogEventsForUser(pool, uid);
+    const state = inferDialogState(rows);
+
+    if (state.type === 'answered') {
+      return { duplicate: userIns === 'duplicate', skipped: true };
     }
-    return { duplicate: ins === 'duplicate', skipped: false };
+
+    if (state.type === 'needs_first_question') {
+      await openIter2SessionAndAskFirstQuestion({
+        pool,
+        config,
+        maxUserId: uid,
+        openingMessageMid: maxUpdateId,
+        log,
+      });
+      return { duplicate: userIns === 'duplicate', skipped: false };
+    }
+
+    if (state.type === 'awaiting_answer') {
+      if (state.openingMessageMid != null && state.openingMessageMid === maxUpdateId) {
+        return { duplicate: userIns === 'duplicate', skipped: true };
+      }
+      const text = m.body?.text ?? '';
+      const ansIns = await insertAnswerGiven(pool, {
+        maxUserId: uid,
+        sessionId: state.sessionId,
+        questionId: state.questionId,
+        answerValue: text,
+        answerType: 'text',
+        maxUpdateId,
+      });
+      if (ansIns === 'inserted' && config.maxBotToken) {
+        await sendMaxUserMessage({
+          baseUrl: config.maxApiBaseUrl,
+          token: config.maxBotToken,
+          userId: uid,
+          text: config.dialogAnswerAckText,
+        });
+      } else if (ansIns === 'inserted' && !config.maxBotToken) {
+        log.warn('MAX_BOT_TOKEN empty: skip answer ack');
+      }
+      return { duplicate: userIns === 'duplicate', skipped: false };
+    }
+
+    return { duplicate: userIns === 'duplicate', skipped: true };
   }
 
   return { duplicate: false, skipped: true };

--- a/tests/dialog-state.test.ts
+++ b/tests/dialog-state.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { CORE_FIRST_QUESTION_ID } from '../src/dialog/constants.js';
+import { inferDialogState, type DialogEventRow } from '../src/dialog/resolve-state.js';
+
+function row(type: string, payload: Record<string, unknown>): DialogEventRow {
+  return { event_type: type, payload };
+}
+
+describe('inferDialogState', () => {
+  it('needs_first_question after user.started only', () => {
+    const events: DialogEventRow[] = [row('user.started', { max_user_id: 1 })];
+    expect(inferDialogState(events)).toEqual({ type: 'needs_first_question' });
+  });
+
+  it('awaiting_answer after session.opened + question.asked for core:first', () => {
+    const sid = 'sess-1';
+    const events: DialogEventRow[] = [
+      row('user.started', { max_user_id: 1 }),
+      row('session.opened', {
+        session_id: sid,
+        max_user_id: 1,
+        opening_message_mid: 'm-open',
+      }),
+      row('question.asked', {
+        session_id: sid,
+        question_id: CORE_FIRST_QUESTION_ID,
+        max_user_id: 1,
+      }),
+    ];
+    expect(inferDialogState(events)).toEqual({
+      type: 'awaiting_answer',
+      sessionId: sid,
+      questionId: CORE_FIRST_QUESTION_ID,
+      openingMessageMid: 'm-open',
+    });
+  });
+
+  it('answered after answer.given for core:first', () => {
+    const sid = 'sess-1';
+    const events: DialogEventRow[] = [
+      row('user.started', { max_user_id: 1 }),
+      row('session.opened', { session_id: sid, max_user_id: 1 }),
+      row('question.asked', {
+        session_id: sid,
+        question_id: CORE_FIRST_QUESTION_ID,
+        max_user_id: 1,
+      }),
+      row('answer.given', {
+        session_id: sid,
+        question_id: CORE_FIRST_QUESTION_ID,
+        max_user_id: 1,
+      }),
+    ];
+    expect(inferDialogState(events)).toEqual({ type: 'answered' });
+  });
+
+  it('bot_started session has null openingMessageMid in awaiting_answer', () => {
+    const sid = 'sess-b';
+    const events: DialogEventRow[] = [
+      row('user.started', { max_user_id: 2 }),
+      row('session.opened', { session_id: sid, max_user_id: 2 }),
+      row('question.asked', {
+        session_id: sid,
+        question_id: CORE_FIRST_QUESTION_ID,
+        max_user_id: 2,
+      }),
+    ];
+    expect(inferDialogState(events)).toEqual({
+      type: 'awaiting_answer',
+      sessionId: sid,
+      questionId: CORE_FIRST_QUESTION_ID,
+      openingMessageMid: null,
+    });
+  });
+});

--- a/tests/event-store.integration.test.ts
+++ b/tests/event-store.integration.test.ts
@@ -1,5 +1,6 @@
 import pg from 'pg';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { CORE_FIRST_QUESTION_ID } from '../src/dialog/constants.js';
 import { runMigrations } from '../src/db/migrate.js';
 import { insertEvent } from '../src/db/insert-event.js';
 import { handleMaxWebhook } from '../src/services/webhook-service.js';
@@ -18,6 +19,8 @@ describe.skipIf(!dsn)('event store (integration)', () => {
     maxWebhookSecret: '',
     maxApiBaseUrl: 'https://platform-api.max.ru',
     logLevel: 'silent',
+    firstCoreQuestionText: 'Тестовый первый вопрос?',
+    dialogAnswerAckText: 'Ок.',
   };
 
   const log = {
@@ -82,5 +85,109 @@ describe.skipIf(!dsn)('event store (integration)', () => {
       `SELECT count(*)::text AS c FROM events WHERE event_type = 'user.started' AND payload->>'max_user_id' = '4242'`,
     );
     expect(r.rows[0].c).toBe('1');
+  });
+
+  it('iter-2: first message creates session.opened and question.asked', async () => {
+    const u1: MaxUpdate = {
+      update_type: 'message_created',
+      timestamp: 1,
+      message: {
+        timestamp: 1,
+        body: { mid: 'mid-iter2-1', text: 'hi' },
+        sender: { user_id: 9100, is_bot: false },
+      },
+    };
+    await handleMaxWebhook({ config: testConfig, pool, update: u1, log });
+    const types = await pool.query<{ event_type: string }>(
+      `SELECT event_type FROM events ORDER BY occurred_at`,
+    );
+    expect(types.rows.map((r) => r.event_type)).toEqual([
+      'user.started',
+      'session.opened',
+      'question.asked',
+    ]);
+  });
+
+  it('iter-2: second message appends answer.given', async () => {
+    const u1: MaxUpdate = {
+      update_type: 'message_created',
+      timestamp: 1,
+      message: {
+        timestamp: 1,
+        body: { mid: 'mid-iter2-a', text: 'hi' },
+        sender: { user_id: 9101, is_bot: false },
+      },
+    };
+    const u2: MaxUpdate = {
+      update_type: 'message_created',
+      timestamp: 2,
+      message: {
+        timestamp: 2,
+        body: { mid: 'mid-iter2-b', text: 'мой ответ' },
+        sender: { user_id: 9101, is_bot: false },
+      },
+    };
+    await handleMaxWebhook({ config: testConfig, pool, update: u1, log });
+    await handleMaxWebhook({ config: testConfig, pool, update: u2, log });
+    const types = await pool.query<{ event_type: string }>(
+      `SELECT event_type FROM events ORDER BY occurred_at`,
+    );
+    expect(types.rows.map((r) => r.event_type)).toEqual([
+      'user.started',
+      'session.opened',
+      'question.asked',
+      'answer.given',
+    ]);
+    const ans = await pool.query<{ answer_value: string }>(
+      `SELECT payload->>'answer_value' AS answer_value FROM events WHERE event_type = 'answer.given'`,
+    );
+    expect(ans.rows[0].answer_value).toBe('мой ответ');
+  });
+
+  it('iter-2: duplicate answer webhook does not duplicate answer.given', async () => {
+    const u1: MaxUpdate = {
+      update_type: 'message_created',
+      timestamp: 1,
+      message: {
+        timestamp: 1,
+        body: { mid: 'mid-iter2-d1', text: 'hi' },
+        sender: { user_id: 9102, is_bot: false },
+      },
+    };
+    const u2: MaxUpdate = {
+      update_type: 'message_created',
+      timestamp: 2,
+      message: {
+        timestamp: 2,
+        body: { mid: 'mid-iter2-d2', text: 'ans' },
+        sender: { user_id: 9102, is_bot: false },
+      },
+    };
+    await handleMaxWebhook({ config: testConfig, pool, update: u1, log });
+    await handleMaxWebhook({ config: testConfig, pool, update: u2, log });
+    await handleMaxWebhook({ config: testConfig, pool, update: u2, log });
+    const c = await pool.query<{ c: string }>(`SELECT count(*)::text AS c FROM events WHERE event_type = 'answer.given'`);
+    expect(c.rows[0].c).toBe('1');
+  });
+
+  it('iter-2: duplicate first message does not insert answer.given', async () => {
+    const u1: MaxUpdate = {
+      update_type: 'message_created',
+      timestamp: 1,
+      message: {
+        timestamp: 1,
+        body: { mid: 'mid-iter2-open-dup', text: 'hi' },
+        sender: { user_id: 9103, is_bot: false },
+      },
+    };
+    await handleMaxWebhook({ config: testConfig, pool, update: u1, log });
+    await handleMaxWebhook({ config: testConfig, pool, update: u1, log });
+    const c = await pool.query<{ c: string }>(`SELECT count(*)::text AS c FROM events WHERE event_type = 'answer.given'`);
+    expect(c.rows[0].c).toBe('0');
+    const q = await pool.query<{ c: string }>(
+      `SELECT count(*)::text AS c FROM events WHERE event_type = 'question.asked' AND payload->>'question_id' = $1`,
+      [CORE_FIRST_QUESTION_ID],
+    );
+    expect(q.rows[0].c).toBe('1');
   });
 });


### PR DESCRIPTION
Цель

Закрывает Iteration 2 из [docs/GITHUB_ISSUES.md](vscode-file://vscode-app/c:/Users/Admin/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/docs/GITHUB_ISSUES.md) → Issue 3: открытие сессии, один статичный первый вопрос Core, сохранение ответа как answer.given, минимальный контекст из событий в events.

Что сделано

События session.opened, question.asked (question_id: core:first), answer.given через [insertEvent](vscode-file://vscode-app/c:/Users/Admin/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/src/db/insert-event.ts); correlation_id = session_id для сессионных событий; в payload max_user_id, для ответа — max_update_id.
Идемпотентность: session.opened:iter2:${user}, question.asked:iter2:core:first:${user}, answer.given:${max_update_id}; в session.opened при входе с message_created — opening_message_mid, чтобы ретрай первого вебхука не шёл в ответ.
[src/dialog/resolve-state.ts](vscode-file://vscode-app/c:/Users/Admin/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/src/dialog/resolve-state.ts) — inferDialogState; [src/db/dialog-events.ts](vscode-file://vscode-app/c:/Users/Admin/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/src/db/dialog-events.ts) — выборка событий по пользователю.
[src/services/webhook-service.ts](vscode-file://vscode-app/c:/Users/Admin/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/src/services/webhook-service.ts) — сценарий: первый контакт → сессия + вопрос + отправка текста; следующее сообщение → answer.given + короткий ack.
Конфиг: firstCoreQuestionText, dialogAnswerAckText 1, опционально env в [.env.example](vscode-file://vscode-app/c:/Users/Admin/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/.env.example).
[docs/SPEC/events.md](vscode-file://vscode-app/c:/Users/Admin/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/docs/SPEC/events.md) — раздел про iter-2 (ключи, payload).
Тесты: [tests/dialog-state.test.ts](vscode-file://vscode-app/c:/Users/Admin/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/tests/dialog-state.test.ts), сценарии iter-2 в [tests/event-store.integration.test.ts](vscode-file://vscode-app/c:/Users/Admin/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/tests/event-store.integration.test.ts).
скрипт очистки events для ручного теста (npm run db:clear / db:clear:test).

Проверка (ручная)

docker compose up (или Postgres + приложение), в .env: DATABASE_URL, MAX_BOT_TOKEN, вебхук через npm run max:subscribe.
В MAX: первое сообщение → текст первого вопроса; ответ → Спасибо, ответ записан! (или свой DIALOG_ANSWER_ACK_TEXT).
npm run build и npm test — зелёные (при TEST_DATABASE_URL / npm run test:db:prepare).

Связь с issue
Closes #3 